### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2025.1.31
 chardet==5.2.0
 drawille==0.1.0
-idna==2.7
+idna>=3.7
 lehar==0.4
 npyscreen==4.10.5
 psutil==5.6.6


### PR DESCRIPTION
Impact

A specially crafted argument to the idna.encode() function could consume significant resources. This may lead to a denial-of-service. Patches

The function has been refined to reject such strings without the associated resource consumption in version 3.7. Workarounds

Domain names cannot exceed 253 characters in length, if this length limit is enforced prior to passing the domain to the idna.encode() function it should no longer consume significant resources. This is triggered by arbitrarily large inputs that would not occur in normal usage, but may be passed to the library assuming there is no preliminary input validation by the higher-level application. References

    https://huntr.com/bounties/93d78d07-d791-4b39-a845-cbfabc44aadb